### PR TITLE
fix demo

### DIFF
--- a/js/newsletter.js
+++ b/js/newsletter.js
@@ -1,5 +1,5 @@
-import { local as store } from 'superstore-sync';
-import { broadcast } from 'n-ui-foundations';
+const store = require('superstore-sync').local;
+const broadcast = require('n-ui-foundations');
 const Feedback = require('./feedback-messaging');
 const apiOptions = {
 	method: 'POST',


### PR DESCRIPTION
It couldn't run demo correctly because of a webpack bug.
this error happens when run demo.
`Cannot assign to read only property 'exports' of object '#<Object>'`
https://github.com/webpack/webpack/issues/4039