### PR TITLE
Setting serif font for description

### DIFF
--- a/styles/newsletter.scss
+++ b/styles/newsletter.scss
@@ -62,6 +62,7 @@ $o-grid-gutter-small: oGridGutter(S);
 }
 
 .n-newsletter-signup__description {
+	@include oTypographySerif($scale: 1);
 	display: inline-block;
 	flex-grow: 1;
 	margin-top: 12px;


### PR DESCRIPTION
Issue was raised in Ops Cops https://trello.com/c/jZf1J14F/199-the-font-on-the-nbe-single-click-sign-up-looks-smaller-than-it-should

The article class `n-content-body` was removed from the container and the `n-newsletter-signup__description` element didn't have the correct font set.

| Before | After |
| --- | --- |
| <img width="478" alt="screen shot 2018-08-22 at 10 40 51" src="https://user-images.githubusercontent.com/1721150/44456306-12c25c00-a5f8-11e8-9742-4d3db6af0664.png"> | <img width="482" alt="screen shot 2018-08-22 at 10 39 36" src="https://user-images.githubusercontent.com/1721150/44456321-181fa680-a5f8-11e8-8c5f-58fffc6ec759.png"> |

