### PR TITLE
Upgrade to o-labels 4.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "homepage": "https://github.com/Financial-Times/n-newsletter-signup",
   "dependencies": {
-    "o-labels": "^3.0.0",
+    "o-labels": "^4.0.0",
     "n-ui-foundations": "^3.0.0",
     "n-myft-ui": "^18.1.5",
     "o-icons": ">=4.0.0 <6",

--- a/styles/newsletter.scss
+++ b/styles/newsletter.scss
@@ -54,11 +54,15 @@ $o-grid-gutter-small: oGridGutter(S);
 }
 
 .n-newsletter-signup__top-meta {
+	@include oLabelsContent($opts: (
+		'base': true,
+        'size': 'small',
+        'state': 'content-premium'
+	));
 	@include oTypographySansBold($scale: 0);
 	position: absolute;
 	top: 0;
 	right: 16px;
-	@include oLabels('premium', 0);
 }
 
 .n-newsletter-signup__description {

--- a/templates/newsletter.html
+++ b/templates/newsletter.html
@@ -1,7 +1,7 @@
 <section data-component="n-newsletter-signup" data-newsletter-id="{{id}}" data-newsletter-name="{{name}}" class="n-newsletter-signup n-newsletter-signup" {{#if isPremium}}data-newsletter-is-premium{{/if}}>
 	<div class="n-newsletter-signup__header">
 		<h2 class="n-newsletter-signup__heading">{{name}}<span class="o-normalise-visually-hidden">{{#if isPremium}}, premium{{/if}}{{#if frequency}}, {{frequency}}{{/if}}</span></h2>
-		{{#if isPremium}}<span aria-hidden="true" class="n-newsletter-signup__top-meta o-labels o-labels--premium">Premium</span>{{/if}}
+		{{#if isPremium}}<span aria-hidden="true" class="n-newsletter-signup__top-meta o-labels o-labels--content-premium">Premium</span>{{/if}}
 	</div>
 	<div data-component="n-newsletter-signup__description" class="n-newsletter-signup__description">
 		<p class="n-newsletter-signup__body">{{description}}</p>


### PR DESCRIPTION
To allow upstream projects to use later versions of o-teaser.