### PR TITLE
Unpin @financial-times/n-gage

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-newsletter-signup#readme",
   "devDependencies": {
-    "@financial-times/n-gage": "3.4.0",
+    "@financial-times/n-gage": "^3.6.0",
     "@financial-times/n-internal-tool": "^2.1.0",
     "bower": "^1.8.0",
     "bower-resolve-webpack-plugin": "^1.0.4",


### PR DESCRIPTION
This pull requests unpins the @financial-times/n-gage dependency. As a general rule we should not be pinning any of our devDependencies. Please merge this pull requests if all checks are passing.