### PR TITLE
Use exports instead of module.exporting an object

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,13 +1,11 @@
 const Newsletter = require('./newsletter');
 
-module.exports = {
-	init: (containerEl = document.body) => {
-		const newsletterSignupContainers = Array.from(containerEl.querySelectorAll('[data-component="n-newsletter-signup"]'));
-		if (newsletterSignupContainers.length) {
-			newsletterSignupContainers
-			.forEach(instanceEl => {
-				new Newsletter(instanceEl);
-			});
-		}
+exports.init = (containerEl = document.body) => {
+	const newsletterSignupContainers = Array.from(containerEl.querySelectorAll('[data-component="n-newsletter-signup"]'));
+	if (newsletterSignupContainers.length) {
+		newsletterSignupContainers
+		.forEach(instanceEl => {
+			new Newsletter(instanceEl);
+		});
 	}
 };


### PR DESCRIPTION
This isn't interoperable with consumers importing it as an ECMAScript module (but, it used to mistakenly work because our tooling was too lenient)

@i-like-robots can you provide more detail on this? It's started breaking `n-magnet` and we're not sure what's changed, but I do know this is exactly the case that breaks things