### PR TITLE
Add Snyk to components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
+      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/n-newsletter-signup
       - run:
           name: shared-helper / npm-version-and-publish-public
           command: .circleci/shared-helpers/helper-npm-version-and-publish-public

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
+version: v1.13.5
+ignore: {}
+patch: {}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "precommit": "node_modules/.bin/secret-squirrel",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
-    "prepush": "make verify -j3"
+    "prepush": "make verify -j3",
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "repository": {
     "type": "git",
@@ -26,6 +27,7 @@
     "bower-resolve-webpack-plugin": "^1.0.4",
     "node-sass": "^4.5.3",
     "pa11y-ci": "^2.1.1",
+    "snyk": "^1.168.0",
     "webpack": "^3.5.2"
   }
 }


### PR DESCRIPTION
We are installing [Snyk](https://snyk.io) in all of our repos for security reasons. It will patch or ignore known vulnerabilities. Currently Snyk is enabled on our repos (config and results can be viewed from the Snyk webpage) but we want to install it on each project for increased security when building. See https://github.com/Financial-Times/next/issues/365