### PR TITLE
ACC-1169 node already in v12, bump up n-gage, change master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,13 @@ references:
     restore_cache:
         <<: *npm_cache_keys
 
-  filters_only_master: &filters_only_master
+  filters_only_main: &filters_only_main
     branches:
-      only: master
+      only: main
 
-  filters_ignore_master: &filters_ignore_master
+  filters_ignore_main: &filters_ignore_main
     branches:
-      ignore: master
+      ignore: main
 
   filters_ignore_tags: &filters_ignore_tags
     tags:
@@ -154,7 +154,7 @@ workflows:
       - schedule:
           cron: "0 0 * * *"
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
     jobs:
       - build:
           context: next-nightly-build

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,7 +1,7 @@
 linters:
 
   # Documentation:
-  # https://github.com/causes/scss-lint/blob/master/lib/scss_lint/linter/README.md
+  # https://github.com/causes/scss-lint/blob/main/lib/scss_lint/linter/README.md
 
   # "value !important;" not "value!important ;"
   BangFormat:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-newsletter-signup#readme",
   "devDependencies": {
-    "@financial-times/n-gage": "^6.0.0",
+    "@financial-times/n-gage": "^8.2.0",
     "@financial-times/n-internal-tool": "^2.1.0",
     "bower": "^1.8.8",
     "bower-resolve-webpack-plugin": "^1.0.4",


### PR DESCRIPTION
node was already running v12
n-gage version bumped up to 8.2.0 in package.json
rename master to main in circle ci file
closes #59 