### PR TITLE
acc-1487: add npm publish token context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,7 @@ workflows:
           requires:
             - build
       - publish:
+          context: npm-publish-token
           filters:
             <<: *filters_version_tag
           requires:


### PR DESCRIPTION
Add npm publish token context to circleci
[ACC-1487](https://financialtimes.atlassian.net/browse/ACC-1487)