### PR TITLE
Replace "email" with "newsletter"

### DIFF
--- a/templates/simple.html
+++ b/templates/simple.html
@@ -1,5 +1,5 @@
 <section data-component="n-newsletter-signup" data-newsletter-id="{{id}}" data-newsletter-name="{{name}}" class="n-newsletter-signup n-newsletter-signup--simple" {{#if isPremium}}data-newsletter-is-premium{{/if}}>
-	<span class="n-newsletter-signup__description">Sign up to the {{name}} email, {{frequency}} </span>
+	<span class="n-newsletter-signup__description">Sign up to the {{name}} newsletter, {{frequency}} </span>
 
 	{{#if userNeedsToUpgrade}}
 		<a href="/products?location=/newsletters" class="n-newsletter-signup__upgrade" data-trackable="newsletters-upgrade">Upgrade<span class="o-normalise-visually-hidden">&nbsp; your subscription to receive {{name}}</span></a>


### PR DESCRIPTION
Stakeholders have requested this wording change


<img width="811" alt="Screenshot of the sign up to the newsletter promo" src="https://user-images.githubusercontent.com/524573/166965783-76653f1e-8d92-44de-9b53-dae2d8d46500.png">
