### PR TITLE
UG-1090: Change the accessible name on the sign-up form to include the visual label

### DIFF
--- a/templates/partials/newsletter-form.html
+++ b/templates/partials/newsletter-form.html
@@ -18,7 +18,7 @@
 			{{~#if userIsSubscribed~}}
 				Unsubscribe from {{name}}
 			{{~else~}}
-				Subscribe to {{name}}
+				One-Click Sign Up subscribe to {{name}}
 			{{~/if~}}
 		"
 		title="


### PR DESCRIPTION
### Description
The accessible name on the sign-up button should contain the visual label text to be able to be activated by voice commands. This PR changes the `aria-label` value to include the label text.

### Ticket
[UG-1090](https://financialtimes.atlassian.net/browse/UG-1090)

### How to test this code?
- Check out this branch locally and run `npm link`
- Check out `next-article` and run `npm link @financial-times/n-newsletter-signup` to generate a symlink to your local version of the package
- Run `npm run build` and `npm start` on `next-article`
- Go to [an article](https://local.ft.com:5050/content/80670e39-1b23-4714-a945-c3b0e3dd9b2f) that includes the newsletter sign-up button
- Switch on your screen reader, put the focus on the `One-Click Sign Up` button and confirm that it reads `One-Click Sign up subscribe to {{name-of-the-newsletter}}`